### PR TITLE
make isort black-compatible

### DIFF
--- a/{{cookiecutter.package_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.package_name}}/.pre-commit-config.yaml
@@ -24,6 +24,7 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
+        args: ["--profile", "black"]
         files: \.py$
 
   - repo: https://github.com/pre-commit/mirrors-mypy


### PR DESCRIPTION
`isort` rules sometimes conflict with `black` rules, and compatibility must be specified manually. See this issue: https://github.com/PyCQA/isort/issues/1518