### PR TITLE
add extension name to endpoint route 

### DIFF
--- a/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/extension.py
+++ b/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/extension.py
@@ -8,7 +8,7 @@ class Extension(ExtensionApp):
 
     name = "{{ cookiecutter.package_name | replace('-', '_') }}"
     handlers = [
-        ("ping", PingHandler)
+        ("{{ cookiecutter.package_name | replace('_', '-') }}/ping", PingHandler)
     ]
 
     # Example of a configurable trait. This is meant to be replaced

--- a/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/tests/test_handlers.py
+++ b/{{cookiecutter.package_name}}/{{cookiecutter.package_name}}/tests/test_handlers.py
@@ -2,7 +2,7 @@ import json
 
 
 async def test_get(jp_fetch):
-    response = await jp_fetch("ping")
+    response = await jp_fetch("{{ cookiecutter.package_name | replace('_', '-') }}/ping")
 
     assert response.code == 200
     payload = json.loads(response.body)


### PR DESCRIPTION
fix for #14. adds extension name in front of /ping route to demonstrate the best practice of route namespacing

test calls after changes 
<img width="1392" alt="Screen Shot 2022-09-11 at 8 40 43 PM" src="https://user-images.githubusercontent.com/20909250/189559963-8143427c-d5f3-4be2-882d-c4cde56c7444.png">
<img width="1392" alt="Screen Shot 2022-09-11 at 8 40 52 PM" src="https://user-images.githubusercontent.com/20909250/189559995-c32d10fc-555a-4d78-aab7-e2bc71a92a99.png">
